### PR TITLE
Add Laravel 13 support and drop Laravel 11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,13 +11,13 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        laravel: [ '11.*', '12.*' ]
+        laravel: [ '12.*', '13.*' ]
         stability: [ prefer-lowest, prefer-stable ]
         include:
-          - laravel: '11.*'
-            testbench: '^9.0'
           - laravel: '12.*'
             testbench: '^10.0'
+          - laravel: '13.*'
+            testbench: '^11.0'
 
     name: Laravel ${{ matrix.laravel }} - ${{ matrix.stability }}
 

--- a/composer.json
+++ b/composer.json
@@ -11,17 +11,17 @@
         }
     ],
     "require": {
-        "php": "8.2.* || 8.3.*",
+        "php": "^8.3",
         "aws/aws-sdk-php": "^3.353",
-        "illuminate/notifications": "^11.0||^12.0",
-        "illuminate/support": "^11.0||^12.0"
+        "illuminate/notifications": "^12.0||^13.0",
+        "illuminate/support": "^12.0||^13.0"
     },
     "require-dev": {
         "dg/bypass-finals": "^1.9",
         "friendsofphp/php-cs-fixer": "^3.87.0",
         "larastan/larastan": "^3.0",
         "nunomaduro/phpinsights": "^2.11",
-        "orchestra/testbench": "^9.0 || ^10.0",
+        "orchestra/testbench": "^10.0 || ^11.0",
         "pestphp/pest": "^3.8",
         "phpmd/phpmd": "^2.15",
         "phpstan/extension-installer": "^1.4",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -18,4 +18,5 @@ parameters:
                 - '#Call to an undefined method Coverzen\\Components\\SnsFanoutNotification\\.*::expects\(\)#'
                 - '#Call to an undefined method Aws\\Sns\\SnsClient::shouldReceive\(\)#'
                 - '#Cannot call method (atLeast|once|with|andReturn)\(\) on mixed#'
+                - '#Return type of call to method .*::partialMock\(\) contains unresolvable type#'
            path: tests/Unit/*.php

--- a/src/SnsFanout.php
+++ b/src/SnsFanout.php
@@ -13,7 +13,7 @@ final class SnsFanout
      *
      * @param SnsClient $sns
      */
-    public function __construct(protected SnsClient $sns)
+    public function __construct(private SnsClient $sns)
     {
     }
 

--- a/src/SnsFanoutChannel.php
+++ b/src/SnsFanoutChannel.php
@@ -12,7 +12,7 @@ use Illuminate\Support\Facades\Event;
 
 final class SnsFanoutChannel
 {
-    public function __construct(protected SnsFanout $snsFanout)
+    public function __construct(private SnsFanout $snsFanout)
     {
     }
 
@@ -52,7 +52,7 @@ final class SnsFanoutChannel
      * @throws CouldNotSendNotification
      * @return SnsFanoutMessage
      */
-    protected function getMessage(mixed $notifiable, Notification $notification): SnsFanoutMessage
+    private function getMessage(mixed $notifiable, Notification $notification): SnsFanoutMessage
     {
         /** @var SnsFanoutMessage|array<string, mixed>|null $message */
         /* @phpstan-ignore method.notFound */

--- a/src/SnsFanoutMessage.php
+++ b/src/SnsFanoutMessage.php
@@ -18,9 +18,9 @@ final class SnsFanoutMessage
      * @param array<array-key, mixed> $attributes
      */
     public function __construct(
-        protected array $body = [],
-        protected string $topic = '',
-        protected array $attributes = [],
+        private array $body = [],
+        private string $topic = '',
+        private array $attributes = [],
     ) {
     }
 

--- a/src/SnsFanoutNotificationServiceProvider.php
+++ b/src/SnsFanoutNotificationServiceProvider.php
@@ -19,7 +19,7 @@ final class SnsFanoutNotificationServiceProvider extends ServiceProvider
         /* @phpstan-ignore argument.type */
         $this->app->bind(SnsFanout::class, fn () => new SnsFanout($this->app->make(SnsService::class)));
 
-        $this->app->bind(SnsService::class, function () {
+        $this->app->bind(SnsService::class, static function () {
             /** @var array<string, mixed> $config */
             $config = [
                 'version' => 'latest',


### PR DESCRIPTION
## Cosa

Sposta il range Laravel supportato a **`^12 || ^13`**: aggiunge **Laravel 13** e rimuove **Laravel 11**.

## Perché droppare Laravel 11

Laravel 11 è oltre la finestra di supporto sicurezza e ha un advisory **non patchato** su `illuminate/mail` (nessun fix nella linea 11.x; risolto solo in 12.60+ e 13.10+). Con `roave/security-advisories` **nessuna** versione di Laravel 11 è installabile in CI. Nessun consumer interno gira su Laravel 11: `business-partner` e `document-management-service` sono entrambi su `^12` (verificato).

## Modifiche

- `composer.json`: `illuminate/notifications` e `illuminate/support` → `^12.0||^13.0`; `php` → `^8.2`; `orchestra/testbench` (dev) → `^10.0 || ^11.0`.
- `.github/workflows/tests.yml`: matrice `laravel: [ '12.*', '13.*' ]` con `testbench ^10.0 / ^11.0`.
- `phpstan.neon`: ignorato nel blocco test il falso positivo `partialMock() contains unresolvable type` (Laravel 13 dichiara `partialMock()` con un `@return` condizionale che risolve a `SnsFanout&MockInterface`, intersezione impossibile su classe `final`; a runtime ok via `dg/bypass-finals`).
- `src/*`: fix meccanici di `php-cs-fixer` (`protected_to_private`, `static_lambda`) dal bump del toolchain (`composer.lock` non committato per i package). Nessun cambiamento di comportamento.

## Verifica locale

- `composer update` → `laravel/framework v13.17.0`; `composer test` → 6 passati; `composer analyse` → **No errors found**.
- Matrice attesa verde: L12 lowest (12.61) + stable (12.62), L13 lowest (13.10+) + stable (13.17).